### PR TITLE
Fix typo: tpye() --> type()

### DIFF
--- a/maskrcnn_benchmark/structures/segmentation_mask.py
+++ b/maskrcnn_benchmark/structures/segmentation_mask.py
@@ -67,7 +67,7 @@ class BinaryMaskList(object):
             masks = masks.masks.clone()
         else:
             RuntimeError(
-                "Type of `masks` argument could not be interpreted:%s" % tpye(masks)
+                "Type of `masks` argument could not be interpreted:%s" % type(masks)
             )
 
         if len(masks.shape) == 2:


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/tianzhi0549/FCOS on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./maskrcnn_benchmark/structures/segmentation_mask.py:70:74: F821 undefined name 'tpye'
                "Type of `masks` argument could not be interpreted:%s" % tpye(masks)
                                                                         ^
./docker/docker-jupyter/jupyter_notebook_config.py:5:5: F821 undefined name 'get_config'
c = get_config()
    ^
2     F821 undefined name 'get_config'
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree