### PR TITLE
Fix torch._six.PY3 not found in newer pytorch versions

### DIFF
--- a/fcos_core/utils/imports.py
+++ b/fcos_core/utils/imports.py
@@ -1,11 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
-import torch
+import sys
 
-if torch._six.PY3:
+if sys.version_info[0] >= 3:
     import importlib
     import importlib.util
-    import sys
-
 
     # from https://stackoverflow.com/questions/67631/how-to-import-a-module-given-the-full-path?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa
     def import_file(module_name, file_path, make_importable=False):


### PR DESCRIPTION
Newer python versions [do not have variable `torch._six.PY3`](https://github.com/pytorch/pytorch/blob/master/torch/_six.py#L27) [[Issue](https://github.com/tianzhi0549/FCOS/issues/358)] which is also a module not meant to be imported in a project.

PY3 only checks that python version is 3, and we can do that directly using sys.

