### PR TITLE
Fix cv2 error Can't parse 'org'. Sequence item with index 0 has a wrong type

### DIFF
--- a/fcos/fcos.py
+++ b/fcos/fcos.py
@@ -372,7 +372,7 @@ class FCOS(object):
             x, y = box[:2]
             s = template.format(label, score)
             cv2.putText(
-                image, s, (x, y), cv2.FONT_HERSHEY_SIMPLEX, .5, (255, 255, 255), 1
+                image, s, (int(x), int(y)), cv2.FONT_HERSHEY_SIMPLEX, .5, (255, 255, 255), 1
             )
 
         return image


### PR DESCRIPTION
`
python bin/fcos https://github.com/tianzhi0549/FCOS/raw/master/demo/images/COCO_val2014_000000000885.jpg
person           confidence: 0.81    bbox: 519.2 345.5 770.4 747.2
tennis racket    confidence: 0.77    bbox: 737.3 502.8 897.9 579.1
person           confidence: 0.72    bbox: 1113.3 47.7 1198.0 470.1
person           confidence: 0.70    bbox: 558.2 161.6 740.8 428.1
person           confidence: 0.52    bbox: 932.5 0.3 1029.0 26.7
person           confidence: 0.50    bbox: 785.0 0.3 869.3 24.4
person           confidence: 0.50    bbox: 1077.1 0.4 1142.3 27.3
person           confidence: 0.49    bbox: 1012.4 0.2 1079.1 27.2
person           confidence: 0.48    bbox: 650.9 0.6 738.5 20.7
Predicted in 0.11 seconds.
Press any key to exit...
Traceback (most recent call last):
  File "/.../fcos/bin/fcos", line 59, in <module>
    fcos.show_bboxes(im, bbox_results)
  File "/.../fcos/fcos.py", line 326, in show_bboxes
    self.overlay_class_names(im, bbox_list)
  File "/.../fcos/fcos.py", line 374, in overlay_class_names
    cv2.putText(
cv2.error: OpenCV(4.5.3) :-1: error: (-5:Bad argument) in function 'putText'
> Overload resolution failed:
>  - Can't parse 'org'. Sequence item with index 0 has a wrong type
>  - Can't parse 'org'. Sequence item with index 0 has a wrong type


Process finished with exit code 1
`